### PR TITLE
update nodeStatus map when node is added

### DIFF
--- a/pkg/ServerUtils/RingServer.go
+++ b/pkg/ServerUtils/RingServer.go
@@ -51,9 +51,11 @@ func (ringServer *RingServer) AddNodeHandler(w http.ResponseWriter, r *http.Requ
 	nodeID := phyNode.ID
 	nodeUrl := fmt.Sprintf("%s:%s", phyNode.IP, phyNode.Port)
 
+
 	actualNodeDataArray := ringServer.ring.RegisterNodes(nodeDataArray)
 	fmt.Printf("Actual Node Data Array Registered %s", actualNodeDataArray)
 
+	ringServer.ring.NodeStatuses[nodeID] = true
 	ringServer.RegisterNodeWithStetho(nodeID, nodeUrl)
 	ringServer.updateRing()
 }


### PR DESCRIPTION
@ChongYiCheng fixed. nodeStatus is updated on the RingServer's ring when node is added. 
As usual, the RingServer will update all nodes of the new ring when that happens. 